### PR TITLE
Validation fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-transforms",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "An ETL framework built upon xlucene-evaluator",
   "srcMain": "src/index.ts",
   "main": "dist/index.js",

--- a/src/operations/lib/validations/boolean.ts
+++ b/src/operations/lib/validations/boolean.ts
@@ -9,9 +9,18 @@ export default class Boolean extends OperationBase {
         super(config);
     }
 
+    isBoolean(field: string | number | undefined): boolean {
+        if (field === undefined) return false;
+        if (_.isBoolean(field)) return true;
+        if (field === 'true' || field === 'false') return true;
+        if (field === '1' || field === 1) return true;
+        if (field === '0' || field === 0) return true;
+        return false;
+    }
+
     run(doc: DataEntity): DataEntity | null {
         const field = _.get(doc, this.source);
-        if (!_.isBoolean(field) && field !== 'true' && field !== 'false') _.unset(doc, this.source);
+        if (!this.isBoolean(field)) _.unset(doc, this.source);
         return doc;
     }
 }

--- a/test/operations/validations/boolean-spec.ts
+++ b/test/operations/validations/boolean-spec.ts
@@ -56,6 +56,43 @@ describe('boolean validation', () => {
         expect(results7).toEqual(data7);
     });
 
+    it('can validate special boolean fields', () => {
+        const opConfig = { source_field: 'isTall' };
+        const test =  new BooleanOp(opConfig);
+        const metaData = { selectors: { 'some:query' : true } };
+
+        const data1 = new DataEntity({ isTall: true }, metaData);
+        const data2 = new DataEntity({ isTall: 'true' }, metaData);
+        const data3 = new DataEntity({ isTall: false }, metaData);
+        const data4 = new DataEntity({ isTall: 'false' });
+        const data5 = new DataEntity({ isTall: 1 }, metaData);
+        const data6 = new DataEntity({ isTall: '1' }, metaData);
+        const data7 = new DataEntity({ isTall: 0 }, metaData);
+        const data8 = new DataEntity({ isTall: '0' });
+
+        const results1 = test.run(data1);
+        const results2 = test.run(data2);
+        const results3 = test.run(data3);
+        const results4 = test.run(data4);
+        const results5 = test.run(data5);
+        const results6 = test.run(data6);
+        const results7 = test.run(data7);
+        const results8 = test.run(data8);
+
+        expect(DataEntity.isDataEntity(results1)).toEqual(true);
+        expect(DataEntity.getMetadata(results1 as DataEntity, 'selectors')).toEqual(metaData.selectors);
+        expect(results1).toEqual(data1);
+        expect(DataEntity.getMetadata(results2 as DataEntity, 'selectors')).toEqual(metaData.selectors);
+        expect(results2).toEqual(data2);
+        expect(results3).toEqual(data3);
+        expect(results4).toEqual(data4);
+        expect(results5).toEqual(data5);
+        expect(results6).toEqual(data6);
+        expect(DataEntity.getMetadata(results6 as DataEntity, 'selectors')).toEqual(metaData.selectors);
+        expect(results7).toEqual(data7);
+        expect(results8).toEqual(data8);
+    });
+
     it('can validate nested fields', async() => {
         const opConfig = { source_field: 'person.isTall' };
         const test =  new BooleanOp(opConfig);

--- a/test/operations/validations/geolocation-spec.ts
+++ b/test/operations/validations/geolocation-spec.ts
@@ -36,6 +36,7 @@ describe('geolocation validation', () => {
         const data7 = new DataEntity({ location: { lat: '56.234', lon: '95.234' } });
         const data8 = new DataEntity({ location: { latitude: '56.234', longitude: '95.234' } }, metaData);
         const data9 = new DataEntity({ location: { longitude: { other:'things' } } });
+        const data10 = new DataEntity({ location: '56.23424357895435,95.23423450985438972' }, metaData);
 
         const results1 = test.run(data1);
         const results2 = test.run(data2);
@@ -46,6 +47,7 @@ describe('geolocation validation', () => {
         const results7 = test.run(data7);
         const results8 = test.run(data8);
         const results9 = test.run(data9);
+        const results10 = test.run(data10);
 
         expect(DataEntity.isDataEntity(results1)).toEqual(true);
         expect(DataEntity.getMetadata(results1 as DataEntity, 'selectors')).toEqual(metaData.selectors);
@@ -61,6 +63,7 @@ describe('geolocation validation', () => {
         expect(results8).toEqual(data8);
         expect(DataEntity.getMetadata(results8 as DataEntity, 'selectors')).toEqual(metaData.selectors);
         expect(results9).toEqual({});
+        expect(results10).toEqual(data10);
     });
 
     it('can validate nested fields', async() => {

--- a/test/transform-spec.ts
+++ b/test/transform-spec.ts
@@ -51,14 +51,16 @@ describe('can transform matches', () => {
 
         const data = DataEntity.makeArray([
             { hostname: 'www.other.com', location: '33.435967,  -111.867710 ' }, //  true
+            { hostname: 'www.other.com', location: '33.435967412341452595678,  -111.8677102345324523452345467456 ' }, //  true
             { hostname: 'www.example.com', location: '22.435967,-150.867710' }  //  false
         ]);
 
         const test = await opTest.init(config);
         const results =  await test.run(data);
 
-        expect(results.length).toEqual(1);
+        expect(results.length).toEqual(2);
         expect(results[0]).toEqual({ point: data[0].location });
+        expect(results[1]).toEqual({ point: data[1].location });
     });
 
     it('it can transform matching data with no selector', async () => {


### PR DESCRIPTION
Fixed the boolean validation issue but I could not replicate the geo validation issues.
Example data used:
`{ location: '33.435967412341452595678, -111.8677102345324523452345467456 }`
