### PR TITLE
Plugin adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-transforms",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "An ETL framework built upon xlucene-evaluator",
   "srcMain": "src/index.ts",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import ExtractionPhase from './phase_manager/extraction_phase';
 import PostProcessPhase from './phase_manager/post_process_phase';
 import ValidationPhase from './phase_manager/validation_phase';
 import Loader from './loader';
+import { OperationsManager } from './operations';
 
 export {
     PhaseManager,
@@ -12,5 +13,6 @@ export {
     ExtractionPhase,
     PostProcessPhase,
     ValidationPhase,
-    Loader
+    Loader,
+    OperationsManager
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,11 +1,12 @@
 
-import PhaseBase from './operations/lib/base';
+import { DataEntity } from '@terascope/job-components';
+
 export enum NotifyType { matcher = 'matcher', transform = 'transform' }
 
 export interface OperationConfig {
     tag?: string;
     selector?: string;
-    selector_config?: object | undefined;
+    types?: object | undefined;
     source_field?: string;
     start?: string;
     end?: string;
@@ -19,18 +20,31 @@ export interface OperationConfig {
     registration_selector?:string;
     mutate?: boolean;
     other_match_required?: boolean;
-}
-// TODO: fix registrationSelector above
-export interface Refs {
-    refs: string;
-    validation?: string;
-    post_process?: string;
+    length?: number;
+    fields?: string[];
+    delimiter?: string;
 }
 
-export interface StringRefs extends Refs {
-    length?: number;
-    target_field?: string;
-    source_field: string;
+export interface SelectorTypes {
+    [field: string]: string;
+}
+
+export type PluginClassConstructor = { new (): PluginClassType };
+
+export interface PluginClassType {
+    init: () => OperationsDict;
+}
+
+export type PluginList = PluginClassConstructor[];
+
+export type BaseOperationClass = { new (config: OperationConfig, types?: SelectorTypes): Operation };
+
+export interface OperationsDict {
+    [op: string]: BaseOperationClass;
+}
+
+export interface Operation {
+    run(data: DataEntity): null | DataEntity;
 }
 
 export interface ConfigResults {
@@ -43,24 +57,15 @@ export interface NormalizedConfig {
     registrationSelector: string;
 }
 
-export interface OperationsDictionary {
-    [key: string]: PhaseBase[];
+export interface OperationsPipline {
+    [key: string]: Operation[];
 }
 
 export interface WatcherConfig {
     type: string;
     rules: string[];
     plugins?: string[];
-    types?: object | undefined;
-}
-
-export interface JoinConfig {
-    selector?: string;
-    operation: string;
-    fields: string[];
-    target_field: string;
-    delimiter?: string;
-    remove_source?: boolean;
+    types?: SelectorTypes;
 }
 
 export type injectFn = (config: OperationConfig, list: OperationConfig[]) => void;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -49,11 +49,9 @@ export interface OperationsDictionary {
 
 export interface WatcherConfig {
     type: string;
-    file_path: string | undefined;
-    connection?: string | undefined;
-    index?: string | undefined;
-    selector_config?: object | undefined;
-    actions?: object[];
+    rules: string[];
+    plugins?: string[];
+    types?: object | undefined;
 }
 
 export interface JoinConfig {

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -2,6 +2,7 @@
 import fs from 'fs';
 import readline from 'readline';
 import { WatcherConfig, OperationConfig } from '../interfaces';
+import _ from 'lodash';
 
 export default class Loader {
     private opConfig: WatcherConfig;
@@ -11,12 +12,9 @@ export default class Loader {
     }
 
     public async load():Promise<OperationConfig[]> {
-        return this.fileLoader();
+        const results = await Promise.all(this.opConfig.rules.map((ruleFile) => this.fileLoader(ruleFile)));
+        return _.flatten(results);
     }
-
-    // private async esLoader() {
-    //     //TODO: implement me
-    // }
 
     private parseConfig(config: string): OperationConfig {
         if (config.charAt(0) !== '{') {
@@ -28,12 +26,12 @@ export default class Loader {
         return results;
     }
 
-    private async fileLoader(): Promise<OperationConfig[]> {
+    private async fileLoader(ruleFile: string): Promise<OperationConfig[]> {
         const parseConfig = this.parseConfig.bind(this);
         const results: OperationConfig[] = [];
 
         const rl = readline.createInterface({
-            input: fs.createReadStream(this.opConfig.file_path as string),
+            input: fs.createReadStream(ruleFile),
             crlfDelay: Infinity
         });
         // TODO: error handling here

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -5,9 +5,9 @@ import Join from './lib/ops/join';
 import Selector from './lib/ops/selector';
 import Extraction  from './lib/ops/extraction';
 import Geolocation from './lib/validations/geolocation';
-import String from './lib/validations/string';
-import Number from './lib/validations/number';
-import Boolean from './lib/validations/boolean';
+import StringValidation from './lib/validations/string';
+import NumberValidation from './lib/validations/number';
+import BooleanValidation from './lib/validations/boolean';
 import Url from './lib/validations/url';
 import Email from './lib/validations/email';
 import Ip from './lib/validations/ip';
@@ -15,17 +15,18 @@ import Base64Decode from './lib/ops/base64decode';
 import UrlDecode from './lib/ops/urldecode';
 import HexDecode from './lib/ops/hexdecode';
 import RequiredExtractions from './lib/validations/required_extractions';
+import { OperationsDict, PluginClassType, BaseOperationClass, PluginList } from '../interfaces';
 
-class CorePlugins {
-    init() {
+class CorePlugins implements PluginClassType {
+    init(): OperationsDict {
         return {
             join: Join,
             selector: Selector,
             extraction: Extraction,
             geolocation: Geolocation,
-            string: String,
-            boolean: Boolean,
-            number: Number,
+            string: StringValidation,
+            boolean: BooleanValidation,
+            number: NumberValidation,
             url: Url,
             email: Email,
             ip: Ip,
@@ -37,31 +38,25 @@ class CorePlugins {
     }
 }
 
-// TODO: Fix me
-interface Operations {
-    [key: string]: Function;
-}
-
 class OperationsManager {
-    operations: Operations;
-    constructor(pluginList: object[] = []) {
+    operations: OperationsDict;
+
+    constructor(pluginList: PluginList = []) {
         pluginList.push(CorePlugins);
+
         const operations = pluginList.reduce((plugins, PluginClass) => {
-            // @ts-ignore
             const plugin = new PluginClass();
             const pluginOps = plugin.init();
             _.assign(plugins, pluginOps);
             return plugins;
         }, {});
-        // @ts-ignore
+
         this.operations = operations;
     }
 
-    getTransform(name: string): OperationBase {
+    getTransform(name: string): BaseOperationClass {
         const op = this.operations[name];
         if (!op) throw new Error(`could not find transform module ${name}`);
-        // TODO: fixme
-        // @ts-ignore
         return op;
     }
 }
@@ -72,9 +67,9 @@ export {
     Selector,
     Extraction,
     Geolocation,
-    String,
-    Number,
-    Boolean,
+    StringValidation,
+    NumberValidation,
+    BooleanValidation,
     Url,
     Email,
     Ip,

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,4 +1,5 @@
 
+import _ from 'lodash';
 import OperationBase from './lib/base';
 import Join from './lib/ops/join';
 import Selector from './lib/ops/selector';
@@ -15,22 +16,55 @@ import UrlDecode from './lib/ops/urldecode';
 import HexDecode from './lib/ops/hexdecode';
 import RequiredExtractions from './lib/validations/required_extractions';
 
-const opNames = {
-    join: Join,
-    selector: Selector,
-    extraction: Extraction,
-    geolocation: Geolocation,
-    string: String,
-    boolean: Boolean,
-    number: Number,
-    url: Url,
-    email: Email,
-    ip: Ip,
-    base64decode: Base64Decode,
-    urldecode: UrlDecode,
-    hexdecode: HexDecode,
-    requiredExtractions: RequiredExtractions
-};
+class CorePlugins {
+    init() {
+        return {
+            join: Join,
+            selector: Selector,
+            extraction: Extraction,
+            geolocation: Geolocation,
+            string: String,
+            boolean: Boolean,
+            number: Number,
+            url: Url,
+            email: Email,
+            ip: Ip,
+            base64decode: Base64Decode,
+            urldecode: UrlDecode,
+            hexdecode: HexDecode,
+            requiredExtractions: RequiredExtractions
+        };
+    }
+}
+
+// TODO: Fix me
+interface Operations {
+    [key: string]: Function;
+}
+
+class OperationsManager {
+    operations: Operations;
+    constructor(pluginList: object[] = []) {
+        pluginList.push(CorePlugins);
+        const operations = pluginList.reduce((plugins, PluginClass) => {
+            // @ts-ignore
+            const plugin = new PluginClass();
+            const pluginOps = plugin.init();
+            _.assign(plugins, pluginOps);
+            return plugins;
+        }, {});
+        // @ts-ignore
+        this.operations = operations;
+    }
+
+    getTransform(name: string): OperationBase {
+        const op = this.operations[name];
+        if (!op) throw new Error(`could not find transform module ${name}`);
+        // TODO: fixme
+        // @ts-ignore
+        return op;
+    }
+}
 
 export {
     OperationBase,
@@ -48,5 +82,5 @@ export {
     UrlDecode,
     HexDecode,
     RequiredExtractions,
-    opNames
+    OperationsManager
 };

--- a/src/operations/lib/ops/join.ts
+++ b/src/operations/lib/ops/join.ts
@@ -1,6 +1,6 @@
 
 import { DataEntity } from '@terascope/job-components';
-import { JoinConfig } from '../../../interfaces';
+import { OperationConfig } from '../../../interfaces';
 import _ from 'lodash';
 import OperationBase from '../base';
 
@@ -8,13 +8,13 @@ export default class Join extends OperationBase {
     private delimiter: string;
     private fields: string[];
 
-    constructor(config: JoinConfig) {
+    constructor(config: OperationConfig) {
         super(config);
         this.delimiter = config.delimiter !== undefined ? config.delimiter : '';
-        this.fields = config.fields;
+        this.fields = config.fields as string[];
     }
     // source work differently here so we do not use the inherited validate
-    protected validate(config: JoinConfig) {
+    protected validate(config: OperationConfig) {
         const { target_field: tField, remove_source } = config;
         if (!tField || typeof tField !== 'string' || tField.length === 0)  {
             throw new Error(`could not find target_field for ${this.constructor.name} validation or it is improperly formatted, config: ${JSON.stringify(config)}`);

--- a/src/operations/lib/ops/selector.ts
+++ b/src/operations/lib/ops/selector.ts
@@ -2,21 +2,21 @@
 import { DocumentMatcher } from 'xlucene-evaluator';
 import { DataEntity } from '@terascope/job-components';
 import OperationBase from '../base';
-import { OperationConfig } from '../../../interfaces';
+import { OperationConfig, SelectorTypes } from '../../../interfaces';
 
 export default class Selector extends OperationBase {
     private documentMatcher: DocumentMatcher;
     public selector: string;
     private isMatchAll: boolean;
 
-    constructor(config: OperationConfig, typeConfigs?: object) {
+    constructor(config: OperationConfig, types?: SelectorTypes) {
         super(config);
         let luceneQuery = config.selector as string;
         if (typeof luceneQuery !== 'string') throw new Error('selector must be a string');
         this.selector = luceneQuery;
         this.isMatchAll = luceneQuery === '*';
         if (this.isMatchAll) luceneQuery = '';
-        this.documentMatcher = new DocumentMatcher(luceneQuery, typeConfigs);
+        this.documentMatcher = new DocumentMatcher(luceneQuery, types);
     }
 
     addMetaData(doc: DataEntity, selector: string) {

--- a/src/operations/lib/validations/boolean.ts
+++ b/src/operations/lib/validations/boolean.ts
@@ -4,7 +4,7 @@ import { OperationConfig } from '../../../interfaces';
 import _ from 'lodash';
 import OperationBase from '../base';
 
-export default class Boolean extends OperationBase {
+export default class BooleanValidation extends OperationBase {
     constructor(config: OperationConfig) {
         super(config);
     }

--- a/src/operations/lib/validations/number.ts
+++ b/src/operations/lib/validations/number.ts
@@ -4,7 +4,7 @@ import { OperationConfig } from '../../../interfaces';
 import _ from 'lodash';
 import OperationBase from '../base';
 
-export default class Number extends OperationBase {
+export default class NumberValidation extends OperationBase {
     constructor(config: OperationConfig) {
         super(config);
     }

--- a/src/operations/lib/validations/string.ts
+++ b/src/operations/lib/validations/string.ts
@@ -1,13 +1,13 @@
 
 import OperationBase from '../base';
 import { DataEntity } from '@terascope/job-components';
-import { StringRefs } from '../../../interfaces';
+import { OperationConfig } from '../../../interfaces';
 import _ from 'lodash';
 
-export default class String extends OperationBase {
+export default class StringValidation extends OperationBase {
     private length?: number;
 
-    constructor(config: StringRefs) {
+    constructor(config: OperationConfig) {
         super(config);
         this.length = config.length;
     }

--- a/src/phase_manager/base.ts
+++ b/src/phase_manager/base.ts
@@ -1,11 +1,11 @@
 
 import { DataEntity } from '@terascope/job-components';
 import _ from 'lodash';
-import { OperationConfig, NormalizedConfig, OperationsDictionary, ConfigResults, injectFn, filterFn } from '../interfaces';
+import { OperationConfig, NormalizedConfig, OperationsPipline, ConfigResults, injectFn, filterFn } from '../interfaces';
 import { OperationsManager } from '../operations';
 
 export default abstract class PhaseBase {
-    readonly phase: OperationsDictionary;
+    readonly phase: OperationsPipline;
     public hasProcessing: boolean;
 
     constructor() {
@@ -29,10 +29,8 @@ export default abstract class PhaseBase {
                     if (type === 'extraction') opName = 'extraction';
                     if (type === 'validation' || type === 'post_process') opName = config[type];
 
-                    // tslint:disable-next-line
                     const Op = opsManager.getTransform(opName as string);
                     if (!this.phase[configData.registrationSelector]) this.phase[configData.registrationSelector] = [];
-                    // @ts-ignore
                     this.phase[configData.registrationSelector].push(new Op(configData.configuration));
                 }
             }

--- a/src/phase_manager/base.ts
+++ b/src/phase_manager/base.ts
@@ -2,7 +2,7 @@
 import { DataEntity } from '@terascope/job-components';
 import _ from 'lodash';
 import { OperationConfig, NormalizedConfig, OperationsDictionary, ConfigResults, injectFn, filterFn } from '../interfaces';
-import * as Operations from '../operations';
+import { OperationsManager } from '../operations';
 
 export default abstract class PhaseBase {
     readonly phase: OperationsDictionary;
@@ -15,7 +15,7 @@ export default abstract class PhaseBase {
 
     abstract run(data: DataEntity[]): DataEntity[];
 
-    protected installOps({ type, filterFn, injectFn }: { type: string, filterFn: filterFn, injectFn?:injectFn} , configList:OperationConfig[]) {
+    protected installOps({ type, filterFn, injectFn }: { type: string, filterFn: filterFn, injectFn?:injectFn} , configList:OperationConfig[], opsManager: OperationsManager) {
         _.forEach(configList, (config: OperationConfig, _ind, list) => {
             if (filterFn(config)) {
                 if (injectFn) {
@@ -30,10 +30,9 @@ export default abstract class PhaseBase {
                     if (type === 'validation' || type === 'post_process') opName = config[type];
 
                     // tslint:disable-next-line
-                    const Op = Operations.opNames[opName as string];
-                    if (!Op) throw new Error(`could not find ${opName} module, config: ${JSON.stringify(config)}`);
-
+                    const Op = opsManager.getTransform(opName as string);
                     if (!this.phase[configData.registrationSelector]) this.phase[configData.registrationSelector] = [];
+                    // @ts-ignore
                     this.phase[configData.registrationSelector].push(new Op(configData.configuration));
                 }
             }

--- a/src/phase_manager/extraction_phase.ts
+++ b/src/phase_manager/extraction_phase.ts
@@ -1,20 +1,21 @@
 import { DataEntity } from '@terascope/job-components';
 import { OperationConfig, WatcherConfig, } from '../interfaces';
 import PhaseBase from './base';
-import * as Ops from '../operations';
 import _ from 'lodash';
+import { OperationsManager, OperationBase } from '../operations';
 
 export default class ExtractionPhase extends PhaseBase {
      // @ts-ignore
     private opConfig: WatcherConfig;
 
-    constructor(opConfig: WatcherConfig, configList:OperationConfig[]) {
+    constructor(opConfig: WatcherConfig, configList:OperationConfig[], opsManager: OperationsManager) {
         super();
         this.opConfig = opConfig;
-
+        const Extraction = opsManager.getTransform('extraction');
         const matchRequireTransforms = (config: OperationConfig, _list:OperationConfig[]) => {
-            _.forOwn(this.phase, (sequence: Ops.OperationBase[], _key) => {
-                sequence.push(new Ops.Extraction(config));
+            _.forOwn(this.phase, (sequence: OperationBase[], _key) => {
+                // @ts-ignore
+                sequence.push(new Extraction(config));
             });
         };
 
@@ -31,7 +32,7 @@ export default class ExtractionPhase extends PhaseBase {
             { type: 'extraction', filterFn: isMatchRequired, injectFn: matchRequireTransforms },
         ];
 
-        sequence.forEach((loadingConfig) => this.installOps(loadingConfig, configList));
+        sequence.forEach((loadingConfig) => this.installOps(loadingConfig, configList, opsManager));
     }
 
     run(dataArray: DataEntity[]): DataEntity[] {

--- a/src/phase_manager/extraction_phase.ts
+++ b/src/phase_manager/extraction_phase.ts
@@ -1,8 +1,9 @@
+
 import { DataEntity } from '@terascope/job-components';
-import { OperationConfig, WatcherConfig, } from '../interfaces';
-import PhaseBase from './base';
 import _ from 'lodash';
-import { OperationsManager, OperationBase } from '../operations';
+import { OperationConfig, WatcherConfig, Operation } from '../interfaces';
+import PhaseBase from './base';
+import { OperationsManager } from '../operations';
 
 export default class ExtractionPhase extends PhaseBase {
      // @ts-ignore
@@ -13,8 +14,7 @@ export default class ExtractionPhase extends PhaseBase {
         this.opConfig = opConfig;
         const Extraction = opsManager.getTransform('extraction');
         const matchRequireTransforms = (config: OperationConfig, _list:OperationConfig[]) => {
-            _.forOwn(this.phase, (sequence: OperationBase[], _key) => {
-                // @ts-ignore
+            _.forOwn(this.phase, (sequence: Operation[], _key) => {
                 sequence.push(new Extraction(config));
             });
         };

--- a/src/phase_manager/index.ts
+++ b/src/phase_manager/index.ts
@@ -7,7 +7,7 @@ import SelectionPhase from './selector_phase';
 import ExtractionPhase from './extraction_phase';
 import PostProcessPhase from './post_process_phase';
 import ValidationPhase from './validation_phase';
-
+import { OperationsManager } from '../operations';
 import PhaseBase from './base';
 
 export default class PhaseManager {
@@ -25,18 +25,19 @@ export default class PhaseManager {
         this.isMatcher = opConfig.type === 'matcher';
     }
 
-    public async init () {
+    public async init (Plugins?: object[]) {
         try {
             const configList = await this.loader.load();
+            const opsManager = new OperationsManager(Plugins);
             const sequence: PhaseBase[] = [
-                new SelectionPhase(this.opConfig, configList),
+                new SelectionPhase(this.opConfig, configList, opsManager),
             ];
 
             if (!this.isMatcher) {
                 sequence.push(
-                    new ExtractionPhase(this.opConfig, configList),
-                    new PostProcessPhase(this.opConfig, configList),
-                    new ValidationPhase(this.opConfig, configList)
+                    new ExtractionPhase(this.opConfig, configList, opsManager),
+                    new PostProcessPhase(this.opConfig, configList, opsManager),
+                    new ValidationPhase(this.opConfig, configList, opsManager)
                 );
             }
 

--- a/src/phase_manager/index.ts
+++ b/src/phase_manager/index.ts
@@ -1,7 +1,7 @@
 
 import { DataEntity, Logger } from '@terascope/job-components';
 import _ from 'lodash';
-import { WatcherConfig } from '../interfaces';
+import { WatcherConfig, PluginList } from '../interfaces';
 import Loader from '../loader';
 import SelectionPhase from './selector_phase';
 import ExtractionPhase from './extraction_phase';
@@ -25,7 +25,7 @@ export default class PhaseManager {
         this.isMatcher = opConfig.type === 'matcher';
     }
 
-    public async init (Plugins?: object[]) {
+    public async init (Plugins?: PluginList) {
         try {
             const configList = await this.loader.load();
             const opsManager = new OperationsManager(Plugins);

--- a/src/phase_manager/post_process_phase.ts
+++ b/src/phase_manager/post_process_phase.ts
@@ -1,8 +1,8 @@
 
 import { DataEntity } from '@terascope/job-components';
+import _ from 'lodash';
 import { OperationConfig, WatcherConfig } from '../interfaces';
 import PhaseBase from './base';
-import _ from 'lodash';
 import { OperationsManager } from '../operations';
 
 export default class PostProcessPhase extends PhaseBase {

--- a/src/phase_manager/post_process_phase.ts
+++ b/src/phase_manager/post_process_phase.ts
@@ -3,9 +3,10 @@ import { DataEntity } from '@terascope/job-components';
 import { OperationConfig, WatcherConfig } from '../interfaces';
 import PhaseBase from './base';
 import _ from 'lodash';
+import { OperationsManager } from '../operations';
 
 export default class PostProcessPhase extends PhaseBase {
-    constructor(_opConfig: WatcherConfig, configList:OperationConfig[]) {
+    constructor(_opConfig: WatcherConfig, configList:OperationConfig[], opsManager: OperationsManager) {
         super();
 
         function isPrimaryPostProcess(config: OperationConfig): boolean {
@@ -19,7 +20,7 @@ export default class PostProcessPhase extends PhaseBase {
             { type: 'post_process', filterFn: isPrimaryPostProcess },
             { type: 'post_process', filterFn: isRefsPostProcess }
         ];
-        sequence.forEach((loadingConfig) => this.installOps(loadingConfig, configList));
+        sequence.forEach((loadingConfig) => this.installOps(loadingConfig, configList, opsManager));
     }
 
     run(dataArray: DataEntity[]): DataEntity[] {

--- a/src/phase_manager/selector_phase.ts
+++ b/src/phase_manager/selector_phase.ts
@@ -1,25 +1,25 @@
 
 import { DataEntity } from '@terascope/job-components';
-import { OperationConfig, WatcherConfig } from '../interfaces';
-import PhaseBase from './base';
-import { OperationsManager, OperationBase } from '../operations';
 import _ from 'lodash';
+import { OperationConfig, WatcherConfig, Operation } from '../interfaces';
+import PhaseBase from './base';
+import { OperationsManager } from '../operations';
 
 export default class SelectionPhase extends PhaseBase {
     private opConfig: WatcherConfig;
-    readonly selectionPhase: OperationBase[];
+    readonly selectionPhase: Operation[];
 
     constructor(opConfig: WatcherConfig, configList:OperationConfig[], opsManager: OperationsManager) {
         super();
         this.opConfig = opConfig;
-        const selectionPhase: OperationBase[] = [];
+        const selectionPhase: Operation[] = [];
         const dict = {};
         const Selector = opsManager.getTransform('selector');
 
         _.forEach(configList, (config: OperationConfig) => {
             if (config.selector && !config.follow && !config.other_match_required) dict[config.selector] = true;
         });
-        // @ts-ignore
+
         _.forOwn(dict, (_value, selector) => selectionPhase.push(new Selector({ selector }, this.opConfig.types)));
         this.selectionPhase = selectionPhase;
     }

--- a/src/phase_manager/selector_phase.ts
+++ b/src/phase_manager/selector_phase.ts
@@ -2,22 +2,25 @@
 import { DataEntity } from '@terascope/job-components';
 import { OperationConfig, WatcherConfig } from '../interfaces';
 import PhaseBase from './base';
-import * as Ops from '../operations';
+import { OperationsManager, OperationBase } from '../operations';
 import _ from 'lodash';
 
 export default class SelectionPhase extends PhaseBase {
     private opConfig: WatcherConfig;
-    readonly selectionPhase: Ops.Selector[];
+    readonly selectionPhase: OperationBase[];
 
-    constructor(opConfig: WatcherConfig, configList:OperationConfig[]) {
+    constructor(opConfig: WatcherConfig, configList:OperationConfig[], opsManager: OperationsManager) {
         super();
         this.opConfig = opConfig;
-        const selectionPhase: Ops.Selector[] = [];
+        const selectionPhase: OperationBase[] = [];
         const dict = {};
+        const Selector = opsManager.getTransform('selector');
+
         _.forEach(configList, (config: OperationConfig) => {
             if (config.selector && !config.follow && !config.other_match_required) dict[config.selector] = true;
         });
-        _.forOwn(dict, (_value, selector) => selectionPhase.push(new Ops.Selector({ selector }, this.opConfig.selector_config)));
+        // @ts-ignore
+        _.forOwn(dict, (_value, selector) => selectionPhase.push(new Selector({ selector }, this.opConfig.types)));
         this.selectionPhase = selectionPhase;
     }
 

--- a/src/phase_manager/validation_phase.ts
+++ b/src/phase_manager/validation_phase.ts
@@ -2,10 +2,10 @@ import { DataEntity } from '@terascope/job-components';
 import { OperationConfig, WatcherConfig } from '../interfaces';
 import PhaseBase from './base';
 import _ from 'lodash';
-import * as Operations from '../operations';
+import { OperationsManager } from '../operations';
 
 export default class ValidationPhase extends PhaseBase {
-    constructor(_opConfig: WatcherConfig, configList:OperationConfig[]) {
+    constructor(_opConfig: WatcherConfig, configList:OperationConfig[], opsManager: OperationsManager) {
         super();
 
         function isPrimaryValidation(config: OperationConfig): boolean {
@@ -29,8 +29,10 @@ export default class ValidationPhase extends PhaseBase {
                 }
             });
             if (Object.keys(requirements).length > 0) {
+                const RequiredExtractions = opsManager.getTransform('requiredExtractions');
                 if (!this.phase['__all']) this.phase['__all'] = [];
-                this.phase.__all.push(new Operations.RequiredExtractions(requirements));
+                // @ts-ignore
+                this.phase.__all.push(new RequiredExtractions(requirements));
             }
         });
 
@@ -39,7 +41,7 @@ export default class ValidationPhase extends PhaseBase {
             { type: 'validation', filterFn: isRefsValidation },
             { type: 'validation', filterFn: isMatchRequired, injectFn: extractionRequirements }
         ];
-        sequence.forEach((loadingConfig) => this.installOps(loadingConfig, configList));
+        sequence.forEach((loadingConfig) => this.installOps(loadingConfig, configList, opsManager));
     }
 
     run(dataArray: DataEntity[]): DataEntity[] {

--- a/src/phase_manager/validation_phase.ts
+++ b/src/phase_manager/validation_phase.ts
@@ -1,7 +1,8 @@
+
 import { DataEntity } from '@terascope/job-components';
+import _ from 'lodash';
 import { OperationConfig, WatcherConfig } from '../interfaces';
 import PhaseBase from './base';
-import _ from 'lodash';
 import { OperationsManager } from '../operations';
 
 export default class ValidationPhase extends PhaseBase {
@@ -31,7 +32,6 @@ export default class ValidationPhase extends PhaseBase {
             if (Object.keys(requirements).length > 0) {
                 const RequiredExtractions = opsManager.getTransform('requiredExtractions');
                 if (!this.phase['__all']) this.phase['__all'] = [];
-                // @ts-ignore
                 this.phase.__all.push(new RequiredExtractions(requirements));
             }
         });

--- a/test/fixtures/plugins/double.ts
+++ b/test/fixtures/plugins/double.ts
@@ -1,0 +1,15 @@
+
+import { DataEntity } from '@terascope/job-components';
+import { OperationConfig } from '../../../src/interfaces';
+import OperationBase from '../../../src/operations/lib/base';
+
+export default class Double extends OperationBase {
+    constructor(config: OperationConfig) {
+        super(config);
+    }
+
+    run(doc: DataEntity) {
+        doc[this.source] = doc[this.source] * 2;
+        return doc;
+    }
+}

--- a/test/fixtures/plugins/index.ts
+++ b/test/fixtures/plugins/index.ts
@@ -1,0 +1,12 @@
+
+import NoOp from './noop';
+import Double from './double';
+
+export default class Plugin {
+    init() {
+        return {
+            noop: NoOp,
+            double: Double
+        };
+    }
+}

--- a/test/fixtures/plugins/noop.ts
+++ b/test/fixtures/plugins/noop.ts
@@ -1,0 +1,14 @@
+
+import { DataEntity } from '@terascope/job-components';
+import { OperationConfig } from '../../../src/interfaces';
+
+export default class NoOp {
+    constructor(operationConfig: OperationConfig) {
+        // @ts-ignore
+        this.operationConfig = operationConfig;
+    }
+
+    run(doc: DataEntity) {
+        return doc;
+    }
+}

--- a/test/fixtures/transformRules18.txt
+++ b/test/fixtures/transformRules18.txt
@@ -1,0 +1,4 @@
+{ "selector": "host:example.com", "source_field": "field1", "start": "field1=", "end": "EOP", "target_field": "field1", "tag": "field1" }
+{ "follow": "field1", "post_process": "noop" }
+{ "selector": "size:2", "source_field": "size", "target_field": "height", "tag": "height" }
+{ "follow": "height", "post_process": "double" }

--- a/test/loader-spec.ts
+++ b/test/loader-spec.ts
@@ -9,7 +9,7 @@ describe('Loader', () => {
     const transformRules16Path = path.join(__dirname, './fixtures/transformRules16.txt');
 
     it('it can instantiate a matcher from file', async () => {
-        const config: WatcherConfig = { file_path: matchRules1Path, type: 'matcher' };
+        const config: WatcherConfig = { rules: [matchRules1Path], type: 'matcher' };
         let loader: Loader;
 
         expect(() => {
@@ -24,7 +24,7 @@ describe('Loader', () => {
     });
 
     it('it can instantiate a transform with operations from file', async () => {
-        const config: WatcherConfig = { file_path: transformRules2Path, type: 'transform' };
+        const config: WatcherConfig = { rules: [transformRules2Path], type: 'transform' };
         let loader: Loader;
 
         expect(() => {
@@ -37,7 +37,7 @@ describe('Loader', () => {
     });
 
     it('it will not add selector: * to config with refs and other_match_required', async () => {
-        const config: WatcherConfig = { file_path: transformRules16Path, type: 'transform' };
+        const config: WatcherConfig = { rules: [transformRules16Path], type: 'transform' };
         let loader: Loader;
 
         expect(() => {

--- a/test/matcher-spec.ts
+++ b/test/matcher-spec.ts
@@ -14,7 +14,6 @@ describe('matcher', () => {
     });
 
     it('can return matching documents', async () => {
-        // TODO: file path needs to be from asset
         const config = {
             rules: [matchRules1Path],
             types: { _created: 'date' },

--- a/test/matcher-spec.ts
+++ b/test/matcher-spec.ts
@@ -16,8 +16,8 @@ describe('matcher', () => {
     it('can return matching documents', async () => {
         // TODO: file path needs to be from asset
         const config = {
-            file_path: matchRules1Path,
-            selector_config: { _created: 'date' },
+            rules: [matchRules1Path],
+            types: { _created: 'date' },
             type: 'matcher'
         };
 
@@ -37,8 +37,8 @@ describe('matcher', () => {
 
     it('it add metadata to returning docs', async () => {
         const config = {
-            file_path: matchRules1Path,
-            selector_config: { _created: 'date' },
+            rules: [matchRules1Path],
+            types: { _created: 'date' },
             type: 'matcher'
         };
 
@@ -59,8 +59,8 @@ describe('matcher', () => {
 
     it('it can match multiple rules', async () => {
         const config = {
-            file_path: matchRules1Path,
-            selector_config: { _created: 'date' },
+            rules: [matchRules1Path],
+            types: { _created: 'date' },
             type: 'matcher'
         };
 

--- a/test/operations/validations/boolean-spec.ts
+++ b/test/operations/validations/boolean-spec.ts
@@ -58,7 +58,7 @@ describe('boolean validation', () => {
 
     it('can validate special boolean fields', () => {
         const opConfig = { source_field: 'isTall' };
-        const test =  new BooleanOp(opConfig);
+        const test =  new BooleanValidation(opConfig);
         const metaData = { selectors: { 'some:query' : true } };
 
         const data1 = new DataEntity({ isTall: true }, metaData);

--- a/test/operations/validations/boolean-spec.ts
+++ b/test/operations/validations/boolean-spec.ts
@@ -1,12 +1,12 @@
 
-import { Boolean as BooleanOp } from '../../../src/operations';
+import { BooleanValidation } from '../../../src/operations';
 import { DataEntity } from '@terascope/job-components';
 
 describe('boolean validation', () => {
 
     it('can instantiate', () => {
         const opConfig = { source_field: 'someField' };
-        expect(() => new BooleanOp(opConfig)).not.toThrow();
+        expect(() => new BooleanValidation(opConfig)).not.toThrow();
     });
 
     it('can properly throw with bad config values', () => {
@@ -15,16 +15,16 @@ describe('boolean validation', () => {
         const badConfig3 = { source_field: {} };
         const badConfig4 = {};
         // @ts-ignore
-        expect(() => new BooleanOp(badConfig1)).toThrow();
-        expect(() => new BooleanOp(badConfig2)).toThrow();
+        expect(() => new BooleanValidation(badConfig1)).toThrow();
+        expect(() => new BooleanValidation(badConfig2)).toThrow();
         // @ts-ignore
-        expect(() => new BooleanOp(badConfig3)).toThrow();
-        expect(() => new BooleanOp(badConfig4)).toThrow();
+        expect(() => new BooleanValidation(badConfig3)).toThrow();
+        expect(() => new BooleanValidation(badConfig4)).toThrow();
     });
 
     it('can validate boolean fields', () => {
         const opConfig = { source_field: 'isTall' };
-        const test =  new BooleanOp(opConfig);
+        const test =  new BooleanValidation(opConfig);
         const metaData = { selectors: { 'some:query' : true } };
 
         const data1 = new DataEntity({ isTall: '56.234,95.234' }, metaData);
@@ -95,7 +95,7 @@ describe('boolean validation', () => {
 
     it('can validate nested fields', async() => {
         const opConfig = { source_field: 'person.isTall' };
-        const test =  new BooleanOp(opConfig);
+        const test =  new BooleanValidation(opConfig);
 
         const data1 = new DataEntity({ isTall: true });
         const data2 = new DataEntity({ isTall: 'true' });

--- a/test/operations/validations/number-spec.ts
+++ b/test/operations/validations/number-spec.ts
@@ -1,12 +1,12 @@
 
-import { Number as NumberOp } from '../../../src/operations';
+import { NumberValidation } from '../../../src/operations';
 import { DataEntity } from '@terascope/job-components';
 
 describe('number validation', () => {
 
     it('can instantiate', () => {
         const opConfig = { source_field: 'someField' };
-        expect(() => new NumberOp(opConfig)).not.toThrow();
+        expect(() => new NumberValidation(opConfig)).not.toThrow();
     });
 
     it('can properly throw with bad config values', () => {
@@ -15,16 +15,16 @@ describe('number validation', () => {
         const badConfig3 = { source_field: {} };
         const badConfig4 = {};
         // @ts-ignore
-        expect(() => new NumberOp(badConfig1)).toThrow();
-        expect(() => new NumberOp(badConfig2)).toThrow();
+        expect(() => new NumberValidation(badConfig1)).toThrow();
+        expect(() => new NumberValidation(badConfig2)).toThrow();
          // @ts-ignore
-        expect(() => new NumberOp(badConfig3)).toThrow();
-        expect(() => new NumberOp(badConfig4)).toThrow();
+        expect(() => new NumberValidation(badConfig3)).toThrow();
+        expect(() => new NumberValidation(badConfig4)).toThrow();
     });
 
     it('can validate number fields', () => {
         const opConfig = { source_field: 'bytes' };
-        const test =  new NumberOp(opConfig);
+        const test =  new NumberValidation(opConfig);
         const metaData = { selectors: { 'some:query' : true } };
 
         const data1 = new DataEntity({ bytes: '56.234,95.234' }, metaData);
@@ -58,7 +58,7 @@ describe('number validation', () => {
 
     it('can validate nested fields', async() => {
         const opConfig = { source_field: 'file.bytes' };
-        const test =  new NumberOp(opConfig);
+        const test =  new NumberValidation(opConfig);
 
         const data1 = new DataEntity({ file: 'something' });
         const data2 = new DataEntity({ file: {} });

--- a/test/operations/validations/string-spec.ts
+++ b/test/operations/validations/string-spec.ts
@@ -1,12 +1,12 @@
 
-import { String as StringOp } from '../../../src/operations';
+import { StringValidation } from '../../../src/operations';
 import { DataEntity } from '@terascope/job-components';
 
 describe('string validation', () => {
 
     it('can instantiate', () => {
         const opConfig = { refs: 'someId', source_field: 'someField' };
-        expect(() => new StringOp(opConfig)).not.toThrow();
+        expect(() => new StringValidation(opConfig)).not.toThrow();
     });
 
     it('can properly throw with bad config values', () => {
@@ -15,18 +15,18 @@ describe('string validation', () => {
         const badConfig3 = { source_field: {} };
         const badConfig4 = {};
         // @ts-ignore
-        expect(() => new StringOp(badConfig1)).toThrow();
+        expect(() => new StringValidation(badConfig1)).toThrow();
         // @ts-ignore
-        expect(() => new StringOp(badConfig2)).toThrow();
+        expect(() => new StringValidation(badConfig2)).toThrow();
         // @ts-ignore
-        expect(() => new StringOp(badConfig3)).toThrow();
+        expect(() => new StringValidation(badConfig3)).toThrow();
         // @ts-ignore
-        expect(() => new StringOp(badConfig4)).toThrow();
+        expect(() => new StringValidation(badConfig4)).toThrow();
     });
 
     it('can validate string fields', () => {
         const opConfig = { refs: 'someId', source_field: 'field' };
-        const test = new StringOp(opConfig);
+        const test = new StringValidation(opConfig);
         const metaData = { selectors: { 'some:query' : true } };
 
         const data1 = new DataEntity({ field: '56.234,95.234' }, metaData);
@@ -60,7 +60,7 @@ describe('string validation', () => {
 
     it('can ensure strings are of certain lengths', () => {
         const opConfig = { refs: 'someId', source_field: 'field', length: 14 };
-        const test =  new StringOp(opConfig);
+        const test =  new StringValidation(opConfig);
         const metaData = { selectors: { 'some:query' : true } };
 
         const data1 = new DataEntity({ field: '56.234,95.234' }, metaData);
@@ -78,7 +78,7 @@ describe('string validation', () => {
 
     it('can validate nested fields', async() => {
         const opConfig = { refs: 'someId', source_field: 'person.name', length: 14 };
-        const test =  new StringOp(opConfig);
+        const test =  new StringValidation(opConfig);
 
         const data1 = new DataEntity({ person: 'something' });
         const data2 = new DataEntity({ person: {} });

--- a/test/phases/extraction_phase-spec.ts
+++ b/test/phases/extraction_phase-spec.ts
@@ -3,26 +3,27 @@ import path from 'path';
 import { DataEntity } from '@terascope/job-components';
 import { ExtractionPhase, Loader } from '../../src';
 import { OperationConfig } from '../../src/interfaces';
+import { OperationsManager } from '../../src/operations';
 
 describe('extraction phase', () => {
 
     async function getConfigList(fileName: string): Promise<OperationConfig[]> {
         const filePath = path.join(__dirname, `../fixtures/${fileName}`);
-        const myFileLoader = new Loader({ type: 'transform', file_path: filePath });
+        const myFileLoader = new Loader({ type: 'transform', rules: [filePath] });
         return myFileLoader.load();
     }
-    // file_path is only used in loader
-    const transformOpconfig = { file_path: 'some/path', type: 'transform' };
+    // rules is only used in loader
+    const transformOpconfig = { rules: ['some/path'], type: 'transform' };
 
     it('can instantiate', async () => {
         const configList = await getConfigList('transformRules1.txt');
 
-        expect(() => new ExtractionPhase(transformOpconfig, configList)).not.toThrow();
+        expect(() => new ExtractionPhase(transformOpconfig, configList, new OperationsManager())).not.toThrow();
     });
 
     it('has the proper properties', async () => {
         const configList = await getConfigList('transformRules1.txt');
-        const extractionPhase = new ExtractionPhase(transformOpconfig, configList);
+        const extractionPhase = new ExtractionPhase(transformOpconfig, configList, new OperationsManager());
 
         expect(extractionPhase.hasProcessing).toEqual(true);
         expect(extractionPhase.phase).toBeDefined();
@@ -39,7 +40,7 @@ describe('extraction phase', () => {
 
     it('has the proper properties with other_match_required', async () => {
         const configList = await getConfigList('transformRules16.txt');
-        const extractionPhase = new ExtractionPhase(transformOpconfig, configList);
+        const extractionPhase = new ExtractionPhase(transformOpconfig, configList, new OperationsManager());
 
         expect(extractionPhase.hasProcessing).toEqual(true);
         expect(extractionPhase.phase).toBeDefined();
@@ -53,7 +54,7 @@ describe('extraction phase', () => {
 
     it('can run and extract data', async () => {
         const configList = await getConfigList('transformRules1.txt');
-        const extractionPhase = new ExtractionPhase(transformOpconfig, configList);
+        const extractionPhase = new ExtractionPhase(transformOpconfig, configList, new OperationsManager());
 
         const data = [
             { some: 'data',  bytes: 367, myfield: 'something' },
@@ -92,7 +93,7 @@ describe('extraction phase', () => {
 
     it('can pick up extractions from other_match_required', async () => {
         const configList = await getConfigList('transformRules14.txt');
-        const extractionPhase = new ExtractionPhase(transformOpconfig, configList);
+        const extractionPhase = new ExtractionPhase(transformOpconfig, configList, new OperationsManager());
         const key = '12345680';
         const date = new Date().toISOString();
 

--- a/test/phases/phase_manager-spec.ts
+++ b/test/phases/phase_manager-spec.ts
@@ -11,13 +11,13 @@ describe('phase manager', () => {
     const transformRules16Path = path.join(__dirname, '../fixtures/transformRules16.txt');
 
     it('can instantiate', async () => {
-        const opConfig = { type: 'matcher', file_path: matchRules1Path };
+        const opConfig = { type: 'matcher', rules: [matchRules1Path] };
         const manager = new PhaseManager(opConfig, logger);
         return manager.init();
     });
 
     it('match only has selection phase activated', async () => {
-        const opConfig = { type: 'matcher', file_path: matchRules1Path };
+        const opConfig = { type: 'matcher', rules: [matchRules1Path] };
         const manager = new PhaseManager(opConfig, logger);
 
         await manager.init();
@@ -30,7 +30,7 @@ describe('phase manager', () => {
     });
 
     it('if type matcher then selection will only occur when given transform rules', async () => {
-        const opConfig = { type: 'matcher', file_path: transformRules17Path };
+        const opConfig = { type: 'matcher', rules: [transformRules17Path] };
         const manager = new PhaseManager(opConfig, logger);
 
         await manager.init();
@@ -43,7 +43,7 @@ describe('phase manager', () => {
     });
 
     it('can load all phases for transform rules', async() => {
-        const opConfig = { type: 'transform', file_path: transformRules16Path };
+        const opConfig = { type: 'transform', rules: [transformRules16Path] };
         const manager = new PhaseManager(opConfig, logger);
 
         await manager.init();
@@ -67,7 +67,7 @@ describe('phase manager', () => {
     });
 
     it('can run an array of data', async() => {
-        const opConfig = { type: 'transform', file_path: transformRules16Path };
+        const opConfig = { type: 'transform', rules: [transformRules16Path] };
         const manager = new PhaseManager(opConfig, logger);
         const str = 'hello';
         const date = new Date().toISOString();

--- a/test/phases/post_process_phase-spec.ts
+++ b/test/phases/post_process_phase-spec.ts
@@ -3,33 +3,34 @@ import path from 'path';
 import { DataEntity } from '@terascope/job-components';
 import { PostProcessPhase, Loader } from '../../src';
 import { OperationConfig } from '../../src/interfaces';
+import { OperationsManager } from '../../src/operations';
 
 describe('post_process phase', () => {
 
     async function getConfigList(fileName: string): Promise<OperationConfig[]> {
         const filePath = path.join(__dirname, `../fixtures/${fileName}`);
-        const myFileLoader = new Loader({ type: 'transform', file_path: filePath });
+        const myFileLoader = new Loader({ type: 'transform', rules: [filePath] });
         return myFileLoader.load();
     }
-    // file_path is only used in loader
-    const transformOpconfig = { file_path: 'some/path', type: 'transform' };
+    // rules is only used in loader
+    const transformOpconfig = { rules: ['some/path'], type: 'transform' };
 
     it('can instantiate', async () => {
         const configList = await getConfigList('transformRules1.txt');
 
-        expect(() => new PostProcessPhase(transformOpconfig, configList)).not.toThrow();
+        expect(() => new PostProcessPhase(transformOpconfig, configList, new OperationsManager())).not.toThrow();
     });
 
     it('has the proper properties', async () => {
         const configList1 = await getConfigList('transformRules1.txt');
-        const postProcessPhase1 = new PostProcessPhase(transformOpconfig, configList1);
+        const postProcessPhase1 = new PostProcessPhase(transformOpconfig, configList1, new OperationsManager());
 
         expect(postProcessPhase1.hasProcessing).toEqual(false);
         expect(postProcessPhase1.phase).toBeDefined();
         expect(Object.keys(postProcessPhase1.phase).length).toEqual(0);
 
         const configList2 = await getConfigList('transformRules17.txt');
-        const postProcessPhase2 = new PostProcessPhase(transformOpconfig, configList2);
+        const postProcessPhase2 = new PostProcessPhase(transformOpconfig, configList2, new OperationsManager());
 
         expect(postProcessPhase2.hasProcessing).toEqual(true);
         expect(postProcessPhase2.phase).toBeDefined();
@@ -43,7 +44,7 @@ describe('post_process phase', () => {
 
     it('can run and process data', async () => {
         const configList = await getConfigList('transformRules17.txt');
-        const postProcessPhase = new PostProcessPhase(transformOpconfig, configList);
+        const postProcessPhase = new PostProcessPhase(transformOpconfig, configList, new OperationsManager());
 
         function encode(str: string) {
             return Buffer.from(str).toString('base64');

--- a/test/phases/selector_phase-spec.ts
+++ b/test/phases/selector_phase-spec.ts
@@ -3,35 +3,36 @@ import path from 'path';
 import { DataEntity } from '@terascope/job-components';
 import { SelectionPhase, Loader } from '../../src';
 import { OperationConfig } from '../../src/interfaces';
+import { OperationsManager } from '../../src/operations';
 
 describe('selector phase', () => {
 
     async function getConfigList(fileName: string): Promise<OperationConfig[]> {
         const filePath = path.join(__dirname, `../fixtures/${fileName}`);
-        const myFileLoader = new Loader({ type: 'transform', file_path: filePath });
+        const myFileLoader = new Loader({ type: 'transform', rules: [filePath] });
         return myFileLoader.load();
     }
     // file_path is only used in loader
-    const transformOpconfig = { file_path: 'some/path', type: 'transform' };
+    const transformOpconfig = { rules: ['some/path'], type: 'transform' };
 
     it('can instantiate', async () => {
         const configList = await getConfigList('transformRules1.txt');
 
-        expect(() => new SelectionPhase(transformOpconfig, configList)).not.toThrow();
+        expect(() => new SelectionPhase(transformOpconfig, configList, new OperationsManager())).not.toThrow();
     });
 
     it('has the proper properties', async () => {
         const configList = await getConfigList('transformRules1.txt');
-        const selectorPhase = new SelectionPhase(transformOpconfig, configList);
+        const selectorPhase = new SelectionPhase(transformOpconfig, configList, new OperationsManager());
 
         expect(selectorPhase.selectionPhase).toBeDefined();
         expect(selectorPhase.selectionPhase.length).toEqual(6);
     });
 
-    it('can run data to match based on selector and selector_config', async () => {
+    it('can run data to match based on selector and types', async () => {
         const configList = await getConfigList('transformRules1.txt');
-        const myOpConfig = Object.assign({}, transformOpconfig, { selector_config: { location: 'geo' } });
-        const selectorPhase = new SelectionPhase(myOpConfig, configList);
+        const myOpConfig = Object.assign({}, transformOpconfig, { types: { location: 'geo' } });
+        const selectorPhase = new SelectionPhase(myOpConfig, configList, new OperationsManager());
         const data = DataEntity.makeArray([
             { some: 'data', isTall: true },
             { some: 'thing else', person: {} },
@@ -50,7 +51,7 @@ describe('selector phase', () => {
 
     it('can match all', async () => {
         const configList = await getConfigList('transformRules3.txt');
-        const selectorPhase = new SelectionPhase(transformOpconfig, configList);
+        const selectorPhase = new SelectionPhase(transformOpconfig, configList, new OperationsManager());
         const data = DataEntity.makeArray([
             { some: 'data', isTall: true },
             { some: 'thing else', person: {} },
@@ -67,11 +68,13 @@ describe('selector phase', () => {
 
     it('can loads only the appropriate selectors and disregards certain ones', async () => {
         const configList = await getConfigList('transformRules16.txt');
-        const selectorPhase = new SelectionPhase(transformOpconfig, configList);
+        const selectorPhase = new SelectionPhase(transformOpconfig, configList, new OperationsManager());
 
         // this is to check that a match-all has not been added
         // by the other_match_required or refs (ie the second and third config in file)
         expect(selectorPhase.selectionPhase.length).toEqual(1);
+        // FIXME: this ignore
+        // @ts-ignore
         expect(selectorPhase.selectionPhase[0].selector).toEqual('host:fc2.com');
     });
 });

--- a/test/phases/validation_phase-spec.ts
+++ b/test/phases/validation_phase-spec.ts
@@ -3,33 +3,34 @@ import path from 'path';
 import { DataEntity } from '@terascope/job-components';
 import { ValidationPhase, Loader } from '../../src';
 import { OperationConfig } from '../../src/interfaces';
+import { OperationsManager } from '../../src/operations';
 
 describe('validation phase', () => {
 
     async function getConfigList(fileName: string): Promise<OperationConfig[]> {
         const filePath = path.join(__dirname, `../fixtures/${fileName}`);
-        const myFileLoader = new Loader({ type: 'transform', file_path: filePath });
+        const myFileLoader = new Loader({ type: 'transform', rules: [filePath] });
         return myFileLoader.load();
     }
     // file_path is only used in loader
-    const transformOpconfig = { file_path: 'some/path', type: 'transform' };
+    const transformOpconfig = { rules: ['some/path'], type: 'transform' };
 
     it('can instantiate', async () => {
         const configList = await getConfigList('transformRules1.txt');
 
-        expect(() => new ValidationPhase(transformOpconfig, configList)).not.toThrow();
+        expect(() => new ValidationPhase(transformOpconfig, configList, new OperationsManager())).not.toThrow();
     });
 
     it('has the proper properties', async () => {
         const configList1 = await getConfigList('transformRules5.txt');
-        const postProcessPhase1 = new ValidationPhase(transformOpconfig, configList1);
+        const postProcessPhase1 = new ValidationPhase(transformOpconfig, configList1, new OperationsManager());
 
         expect(postProcessPhase1.hasProcessing).toEqual(false);
         expect(postProcessPhase1.phase).toBeDefined();
         expect(Object.keys(postProcessPhase1.phase).length).toEqual(0);
 
         const configList2 = await getConfigList('transformRules16.txt');
-        const postProcessPhase2 = new ValidationPhase(transformOpconfig, configList2);
+        const postProcessPhase2 = new ValidationPhase(transformOpconfig, configList2, new OperationsManager());
 
         expect(postProcessPhase2.hasProcessing).toEqual(true);
         expect(postProcessPhase2.phase).toBeDefined();
@@ -41,7 +42,7 @@ describe('validation phase', () => {
 
     it('can run and validate data', async () => {
         const configList = await getConfigList('transformRules4.txt');
-        const postProcessPhase = new ValidationPhase(transformOpconfig, configList);
+        const postProcessPhase = new ValidationPhase(transformOpconfig, configList, new OperationsManager());
 
         const data = [
             new DataEntity({ full_name: 'John Doe' }, { selectors: { 'hello:world': true } }),
@@ -56,7 +57,7 @@ describe('validation phase', () => {
 
     it('can run and validate data for other_match_required', async () => {
         const configList = await getConfigList('transformRules16.txt');
-        const postProcessPhase = new ValidationPhase(transformOpconfig, configList);
+        const postProcessPhase = new ValidationPhase(transformOpconfig, configList, new OperationsManager());
         const date = new Date().toISOString();
         const data = [
             new DataEntity({ some: 'data', date }, { selectors: { 'fc2.com': true } }),

--- a/test/test-harness.ts
+++ b/test/test-harness.ts
@@ -1,15 +1,14 @@
 
 import { PhaseManager } from '../dist';
 import { debugLogger, DataEntity } from '@terascope/job-components';
-import { WatcherConfig } from '../src/interfaces';
+import { WatcherConfig, PluginList } from '../src/interfaces';
 
 const logger = debugLogger('ts-transform');
 
 export default class TestHarness {
-    // @ts-ignore
-    private phaseManager: PhaseManager;
+    private phaseManager!: PhaseManager;
 
-    async init (config: WatcherConfig, plugins?: object) {
+    async init (config: WatcherConfig, plugins?: PluginList) {
         this.phaseManager = new PhaseManager(config, logger);
         await this.phaseManager.init(plugins);
         return this;

--- a/test/test-harness.ts
+++ b/test/test-harness.ts
@@ -9,9 +9,9 @@ export default class TestHarness {
     // @ts-ignore
     private phaseManager: PhaseManager;
 
-    async init (config: WatcherConfig) {
+    async init (config: WatcherConfig, plugins?: object) {
         this.phaseManager = new PhaseManager(config, logger);
-        await this.phaseManager.init();
+        await this.phaseManager.init(plugins);
         return this;
     }
     run(data: DataEntity[]) {

--- a/test/transform-spec.ts
+++ b/test/transform-spec.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import _ from 'lodash';
 import TestHarness from './test-harness';
 import { WatcherConfig } from '../src/interfaces';
+import Plugins from './fixtures/plugins';
 
 describe('can transform matches', () => {
 
@@ -18,8 +19,8 @@ describe('can transform matches', () => {
 
     it('it can transform matching data', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules1.txt'),
-            selector_config: { _created: 'date' },
+            rules: [getPath('transformRules1.txt')],
+            types: { _created: 'date' },
             type: 'transform'
         };
 
@@ -44,8 +45,8 @@ describe('can transform matches', () => {
 
     it('can uses typeConifg', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules1.txt'),
-            selector_config: { location: 'geo' },
+            rules: [getPath('transformRules1.txt')],
+            types: { location: 'geo' },
             type: 'transform'
         };
 
@@ -65,7 +66,7 @@ describe('can transform matches', () => {
 
     it('it can transform matching data with no selector', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules3.txt'),
+            rules: [getPath('transformRules3.txt')],
             type: 'transform'
         };
 
@@ -88,7 +89,7 @@ describe('can transform matches', () => {
 
     it('can work with regex transform queries', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules1.txt'),
+            rules: [getPath('transformRules1.txt')],
             type: 'transform'
         };
 
@@ -109,7 +110,7 @@ describe('can transform matches', () => {
 
     it('can extract using start/end', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules1.txt'),
+            rules: [getPath('transformRules1.txt')],
             type: 'transform'
         };
 
@@ -135,7 +136,7 @@ describe('can transform matches', () => {
 
     it('can extract using start/end on fields that are arrays', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules10.txt'),
+            rules: [getPath('transformRules10.txt')],
             type: 'transform'
         };
         const urls = [
@@ -158,7 +159,7 @@ describe('can transform matches', () => {
 
     it('can merge extacted results', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules1.txt'),
+            rules: [getPath('transformRules1.txt')],
             type: 'transform'
         };
 
@@ -177,7 +178,7 @@ describe('can transform matches', () => {
 
     it('can use post process operations', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules2.txt'),
+            rules: [getPath('transformRules2.txt')],
             type: 'transform'
         };
 
@@ -194,7 +195,7 @@ describe('can transform matches', () => {
 
     it('false validations remove the fields', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules2.txt'),
+            rules: [getPath('transformRules2.txt')],
             type: 'transform'
         };
 
@@ -220,7 +221,7 @@ describe('can transform matches', () => {
 
     it('refs can target the right field', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules4.txt'),
+            rules: [getPath('transformRules4.txt')],
             type: 'transform'
         };
 
@@ -250,7 +251,7 @@ describe('can transform matches', () => {
 
     it('can chain selection => transform => selection', async() => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules5.txt'),
+            rules: [getPath('transformRules5.txt')],
             type: 'transform'
         };
 
@@ -273,7 +274,7 @@ describe('can transform matches', () => {
 
     it('can chain selection => transform => selection => transform', async() => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules6.txt'),
+            rules: [getPath('transformRules6.txt')],
             type: 'transform'
         };
 
@@ -296,17 +297,17 @@ describe('can transform matches', () => {
 
     it('validations work with the different ways to configure them', async() => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules7.txt'),
+            rules: [getPath('transformRules7.txt')],
             type: 'transform'
         };
 
         const config2: WatcherConfig = {
-            file_path: getPath('transformRules8.txt'),
+            rules: [getPath('transformRules8.txt')],
             type: 'transform'
         };
 
         const config3: WatcherConfig = {
-            file_path: getPath('transformRules9.txt'),
+            rules: [getPath('transformRules9.txt')],
             type: 'transform'
         };
 
@@ -360,7 +361,7 @@ describe('can transform matches', () => {
 
     it('can target multiple transforms on the same field', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules10.txt'),
+            rules: [getPath('transformRules10.txt')],
             type: 'transform'
         };
 
@@ -380,12 +381,12 @@ describe('can transform matches', () => {
 
     it('can run', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules11.txt'),
+            rules: [getPath('transformRules11.txt')],
             type: 'transform'
         };
 
         const config2: WatcherConfig = {
-            file_path: getPath('transformRules12.txt'),
+            rules: [getPath('transformRules12.txt')],
             type: 'transform'
         };
 
@@ -417,7 +418,7 @@ describe('can transform matches', () => {
 
     it('it can mutate data in place for transforms', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules13.txt'),
+            rules: [getPath('transformRules13.txt')],
             type: 'transform'
         };
 
@@ -444,7 +445,7 @@ describe('can transform matches', () => {
 
     it('it can transform data if previous transforms had occured', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules14.txt'),
+            rules: [getPath('transformRules14.txt')],
             type: 'transform'
         };
 
@@ -497,7 +498,7 @@ describe('can transform matches', () => {
 
     it('it can transform data if previous transforms had occured with other post_processing', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules15.txt'),
+            rules: [getPath('transformRules15.txt')],
             type: 'transform'
         };
 
@@ -557,7 +558,7 @@ describe('can transform matches', () => {
 
     it('it works like the test before but with different config layout', async () => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules16.txt'),
+            rules: [getPath('transformRules16.txt')],
             type: 'transform'
         };
 
@@ -617,7 +618,7 @@ describe('can transform matches', () => {
 
     it('chaining configurations sample 1', async() => {
         const config: WatcherConfig = {
-            file_path: getPath('transformRules17.txt'),
+            rules: [getPath('transformRules17.txt')],
             type: 'transform'
         };
         const key = '123456789';
@@ -643,6 +644,36 @@ describe('can transform matches', () => {
         });
         expect(results1[1]).toEqual({
             field1: key,
+        });
+    });
+
+    it('can load plugins', async() => {
+        const config: WatcherConfig = {
+            rules: [getPath('transformRules18.txt')],
+            type: 'transform'
+        };
+        const key = '123456789';
+
+        const data = DataEntity.makeArray([
+            { host: 'example.com', field1: `http://www.example.com/path?field1=${key}&value2=moreblah&value3=evenmoreblah` },
+            { host: 'example.com' },
+            { host: 'example.com', field1: 'someRandomStr' },
+            { host: 'example.com', field1: ['someRandomStr', `http://www.example.com/path?field1=${key}&value2=moreblah&value3=evenmoreblah`] },
+            { size: 2 }
+        ]);
+
+        const test1 = await opTest.init(config, [Plugins]);
+        const results1 =  await test1.run(data);
+
+        expect(results1.length).toEqual(3);
+        expect(results1[0]).toEqual({
+            field1: key
+        });
+        expect(results1[1]).toEqual({
+            field1: key,
+        });
+        expect(results1[2]).toEqual({
+            height: 4,
         });
     });
 });

--- a/tslint.json
+++ b/tslint.json
@@ -24,6 +24,7 @@
       "comma-dangle": false,
       "variable-name": [
         true,
+        "allow-pascal-case",
         "ban-keywords",
         "check-format",
         "allow-leading-underscore"


### PR DESCRIPTION
can now work with plugins;
opConfig changes: 
- rules_file && asset_name => rules: ['assetName:path']
- plugins: ['assetName:path']
- selector_config => types
removed actions, connection and index fields

Example: 

```
        {
            type: 'transform',
            rules: ['some/path', 'other/path')],
            plugins: ['path/to/plugin']
            types: { _created: 'date' }
        };
```

Example Plugin:
```

import NoOp from './noop';
import Double from './double';

export default class Plugin {
    init() {
        return {
            noop: NoOp,
            double: Double
        };
    }
}

```